### PR TITLE
Updated requirement for ogc-api-processes-client (PyPI package)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ stac-pydantic
 types-requests
 types-shapely
 uvicorn[standard]
-ogc-api-processes-client @ git+https://github.com/EOEPCA/ogc-api-processes-client.git@refactoring
+ogc-api-processes-client==0.6.0


### PR DESCRIPTION
With this change, the requirements.txt was updated in order to use the PyPI package for ogc-api-processes (instead of the Git repository branch that had been removed in the meantime).